### PR TITLE
Big changes - We're now on v3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ data/
 difficulty_exports/
 map_outputs/
 obj/
+*.log

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,28 +1,19 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {
+            // Use IntelliSense to find out which attributes exist for C# debugging
+            // Use hover for the description of the existing attributes
+            // For further information visit https://github.com/dotnet/vscode-csharp/blob/main/debugger-launchjson.md
             "name": ".NET Core Launch (console)",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/MuseMapalyzr/bin/Debug/net7.0/musemapalyzr-csharp.dll",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/MuseMapalyzr/bin/Debug/netcoreapp7.0-windows/musemapalyzr-csharp.dll",
             "args": [],
-            "cwd": "${workspaceFolder}/MuseMapalyzr/",
-            "console": "internalConsole",
-            "stopAtEntry": false
-        },
-        {
-            "name": ".NET Core Launch (console) w/ Args",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceFolder}/MuseMapalyzr/bin/Debug/net7.0/musemapalyzr-csharp.dll",
-            "args": ["loonboon"],
-            "cwd": "${workspaceFolder}/MuseMapalyzr/",
+            "cwd": "${workspaceFolder}/MuseMapalyzr",
+            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "internalConsole",
             "stopAtEntry": false
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,19 +1,17 @@
 {
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {
-            // Use IntelliSense to find out which attributes exist for C# debugging
-            // Use hover for the description of the existing attributes
-            // For further information visit https://github.com/dotnet/vscode-csharp/blob/main/debugger-launchjson.md
             "name": ".NET Core Launch (console)",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            // If you have changed target frameworks, make sure to update the program path.
             "program": "${workspaceFolder}/MuseMapalyzr/bin/Debug/netcoreapp7.0-windows/musemapalyzr-csharp.dll",
             "args": [],
             "cwd": "${workspaceFolder}/MuseMapalyzr",
-            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
             "console": "internalConsole",
             "stopAtEntry": false
         },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dotnet.defaultSolution": "musemapalyzr-csharp.sln"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "dotnet.defaultSolution": "musemapalyzr-csharp.sln"
-}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,7 +7,7 @@
             "type": "process",
             "args": [
                 "build",
-                "${workspaceFolder}/MuseMapalyzr/musemapalyzr-csharp.csproj",
+                "${workspaceFolder}/musemapalyzr-csharp.sln",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
@@ -19,7 +19,7 @@
             "type": "process",
             "args": [
                 "publish",
-                "${workspaceFolder}/MuseMapalyzr/musemapalyzr-csharp.csproj",
+                "${workspaceFolder}/musemapalyzr-csharp.sln",
                 "/property:GenerateFullPaths=true",
                 "/consoleloggerparameters:NoSummary"
             ],
@@ -33,18 +33,7 @@
                 "watch",
                 "run",
                 "--project",
-                "${workspaceFolder}/MuseMapalyzr/musemapalyzr-csharp.csproj"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        
-        {
-            "label": "test",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "test",
-                "${workspaceFolder}/MuseMapalyzr.Tests/MuseMapalyzr.Tests.csproj"
+                "${workspaceFolder}/musemapalyzr-csharp.sln"
             ],
             "problemMatcher": "$msCompile"
         }

--- a/MuseMapalyzr.Tests/MuseMapalyzr.Tests.csproj
+++ b/MuseMapalyzr.Tests/MuseMapalyzr.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>netcoreapp7.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/MuseMapalyzr/Logger.cs
+++ b/MuseMapalyzr/Logger.cs
@@ -13,8 +13,8 @@ namespace MuseMapalyzr
     public class CustomLogger
     {
 
-        private static LogLevel DebugLevel = LogLevel.Debug;
-        private static bool LogPatternMultipliers = false;
+        private static LogLevel DebugLevel = LogLevel.Info;
+        private static bool LogPatternMultipliers = true;
 
         private static readonly object locker = new object();
         private static CustomLogger instance = null;

--- a/MuseMapalyzr/Logger.cs
+++ b/MuseMapalyzr/Logger.cs
@@ -14,6 +14,7 @@ namespace MuseMapalyzr
     {
 
         private static LogLevel DebugLevel = LogLevel.Debug;
+        private static bool LogPatternMultipliers = false;
 
         private static readonly object locker = new object();
         private static CustomLogger instance = null;
@@ -81,7 +82,7 @@ namespace MuseMapalyzr
 
         public void PatternLog(string message)
         {
-            WriteToPatternFile(message);
+            if (LogPatternMultipliers) WriteToPatternFile(message);
         }
 
 

--- a/MuseMapalyzr/Logger.cs
+++ b/MuseMapalyzr/Logger.cs
@@ -21,11 +21,15 @@ namespace MuseMapalyzr
         private static string Outfile = "logs/logs.log";
         private static StreamWriter LogWriter;
 
+        private static string PatternOutfile = "logs/patterns.log";
+        private static StreamWriter PatternLogWriter;
+
 
         // Private constructor to prevent outside instantiation
         private CustomLogger()
         {
             LogWriter = new StreamWriter(Outfile, false, Encoding.UTF8);
+            PatternLogWriter = new StreamWriter(PatternOutfile, false, Encoding.UTF8);
         }
 
         public static CustomLogger Instance
@@ -49,6 +53,12 @@ namespace MuseMapalyzr
             LogWriter.Flush();
         }
 
+        private void WriteToPatternFile(string message)
+        {
+            PatternLogWriter.WriteLine(message);
+            PatternLogWriter.Flush();
+        }
+
         public void Debug(string message)
         {
             if (DebugLevel <= LogLevel.Debug) WriteToFile(message);
@@ -69,10 +79,17 @@ namespace MuseMapalyzr
             if (DebugLevel <= LogLevel.Error) WriteToFile(message);
         }
 
+        public void PatternLog(string message)
+        {
+            WriteToPatternFile(message);
+        }
+
+
         // Don't forget to provide a method to properly close the StreamWriter
         public void Close()
         {
             LogWriter.Close();
+            PatternLogWriter.Close();
         }
 
     }

--- a/MuseMapalyzr/Logger.cs
+++ b/MuseMapalyzr/Logger.cs
@@ -1,0 +1,79 @@
+using System.Text;
+
+namespace MuseMapalyzr
+{
+
+    public enum LogLevel : int
+    {
+        Debug = 0,
+        Info = 1,
+        Warning = 2,
+        Error = 3
+    }
+    public class CustomLogger
+    {
+
+        private static LogLevel DebugLevel = LogLevel.Debug;
+
+        private static readonly object locker = new object();
+        private static CustomLogger instance = null;
+
+        private static string Outfile = "logs/logs.log";
+        private static StreamWriter LogWriter;
+
+
+        // Private constructor to prevent outside instantiation
+        private CustomLogger()
+        {
+            LogWriter = new StreamWriter(Outfile, false, Encoding.UTF8);
+        }
+
+        public static CustomLogger Instance
+        {
+            get
+            {
+                lock (locker)
+                {
+                    if (instance == null)
+                    {
+                        instance = new CustomLogger();
+                    }
+                    return instance;
+                }
+            }
+        }
+
+        private void WriteToFile(string message)
+        {
+            LogWriter.WriteLine(message);
+            LogWriter.Flush();
+        }
+
+        public void Debug(string message)
+        {
+            if (DebugLevel <= LogLevel.Debug) WriteToFile(message);
+        }
+
+        public void Info(string message)
+        {
+            if (DebugLevel <= LogLevel.Info) WriteToFile(message);
+        }
+
+        public void Warning(string message)
+        {
+            if (DebugLevel <= LogLevel.Warning) WriteToFile(message);
+        }
+
+        public void Error(string message)
+        {
+            if (DebugLevel <= LogLevel.Error) WriteToFile(message);
+        }
+
+        // Don't forget to provide a method to properly close the StreamWriter
+        public void Close()
+        {
+            LogWriter.Close();
+        }
+
+    }
+}

--- a/MuseMapalyzr/Logger.cs
+++ b/MuseMapalyzr/Logger.cs
@@ -14,7 +14,7 @@ namespace MuseMapalyzr
     {
 
         private static LogLevel DebugLevel = LogLevel.Info;
-        private static bool LogPatternMultipliers = true;
+        private static bool LogPatternMultipliers = false;
 
         private static readonly object locker = new object();
         private static CustomLogger instance = null;

--- a/MuseMapalyzr/Program.cs
+++ b/MuseMapalyzr/Program.cs
@@ -89,6 +89,7 @@ namespace MuseMapalyzr
             {
                 if (args.Length > 1 && args[1] == "unranked")
                 {
+                    Console.WriteLine("Graphing unranked");
                     MultiplierGraphing.Graph(false);
                 }
                 else

--- a/MuseMapalyzr/Program.cs
+++ b/MuseMapalyzr/Program.cs
@@ -52,6 +52,8 @@ namespace MuseMapalyzr
 
                     Console.WriteLine($"Analysing : {name} Samplerate: {mMap.SampleRate}");
                     CustomLogger.Instance.Info($"Analysing : {name} Samplerate: {mMap.SampleRate}");
+                    CustomLogger.Instance.PatternLog($"Analysing : {name} Samplerate: {mMap.SampleRate}");
+
                     using (StreamWriter outfile = new StreamWriter($"{Constants.AnalysisDir}/{name}", false, Encoding.UTF8))
                     {
                         DifficultyCalculation.WeightingResults weightResults = difficultyCalculation.CalculateDifficulty(mMap.Notes, outfile, mMap.SampleRate);

--- a/MuseMapalyzr/Program.cs
+++ b/MuseMapalyzr/Program.cs
@@ -81,6 +81,10 @@ namespace MuseMapalyzr
                 // If no arguments are provided, run export all difficulties
                 inputData.CalculateAndExportAllDifficulties(Constants.DataDir);
             }
+            else if (args[0] == "graph")
+            {
+                MultiplierGraphing.Graph();
+            }
             else
             {
                 // If any argument is provided, run filtered difficulties

--- a/MuseMapalyzr/Program.cs
+++ b/MuseMapalyzr/Program.cs
@@ -50,7 +50,7 @@ namespace MuseMapalyzr
                     MuseSwiprMap mMap = MuseSwiprMap.FromKoreographAsset(filename);
                     string name = filename.Split(new string[] { charSeparator }, StringSplitOptions.None)[^1].Split(".asset")[0];
 
-                    Console.WriteLine($"Analysing : {name}");
+                    Console.WriteLine($"Analysing : {name} Samplerate: {mMap.SampleRate}");
 
                     using (StreamWriter outfile = new StreamWriter($"{Constants.AnalysisDir}/{name}", false, Encoding.UTF8))
                     {

--- a/MuseMapalyzr/Program.cs
+++ b/MuseMapalyzr/Program.cs
@@ -51,7 +51,7 @@ namespace MuseMapalyzr
                     string name = filename.Split(new string[] { charSeparator }, StringSplitOptions.None)[^1].Split(".asset")[0];
 
                     Console.WriteLine($"Analysing : {name} Samplerate: {mMap.SampleRate}");
-
+                    CustomLogger.Instance.Info($"Analysing : {name} Samplerate: {mMap.SampleRate}");
                     using (StreamWriter outfile = new StreamWriter($"{Constants.AnalysisDir}/{name}", false, Encoding.UTF8))
                     {
                         DifficultyCalculation.WeightingResults weightResults = difficultyCalculation.CalculateDifficulty(mMap.Notes, outfile, mMap.SampleRate);
@@ -76,6 +76,8 @@ namespace MuseMapalyzr
         {
             InputData inputData = new();
 
+            CustomLogger.Instance.Info("Starting Application");
+
             if (args.Length == 0)
             {
                 // If no arguments are provided, run export all difficulties
@@ -85,7 +87,6 @@ namespace MuseMapalyzr
             {
                 if (args.Length > 1 && args[1] == "unranked")
                 {
-                    Console.WriteLine("Graphing UNRANKED");
                     MultiplierGraphing.Graph(false);
                 }
                 else
@@ -109,6 +110,7 @@ namespace MuseMapalyzr
                 string filterBy = string.Join(" ", args);
                 inputData.CalculateAndExportFilteredDifficulties(filterBy, Constants.DataDir);
             }
+            CustomLogger.Instance.Close(); // Close the logger at the end
         }
     }
 }

--- a/MuseMapalyzr/Program.cs
+++ b/MuseMapalyzr/Program.cs
@@ -55,7 +55,7 @@ namespace MuseMapalyzr
                     using (StreamWriter outfile = new StreamWriter($"{Constants.AnalysisDir}/{name}", false, Encoding.UTF8))
                     {
                         DifficultyCalculation.WeightingResults weightResults = difficultyCalculation.CalculateDifficulty(mMap.Notes, outfile, mMap.SampleRate);
-                        writer.WriteLine($"{filename.Split(new string[] { charSeparator }, StringSplitOptions.None)[^1].Split(".asset")[0]}||{weightResults.WeightedDifficulty:F2}||{weightResults.Weighting:F2}||{weightResults.Difficulty:F2}");
+                        writer.WriteLine($"{filename.Split(new string[] { charSeparator }, StringSplitOptions.None)[^1].Split(".asset")[0]}||{weightResults.RankedWeightedDifficulty:F2}||{weightResults.RankedWeighting:F2}||{weightResults.RankedDifficulty:F2}||{weightResults.UnrankedWeightedDifficulty:F2}||{weightResults.UnrankedWeighting:F2}||{weightResults.UnrankedDifficulty:F2}");
                     }
                     // }
                     // catch (Exception e)
@@ -83,7 +83,25 @@ namespace MuseMapalyzr
             }
             else if (args[0] == "graph")
             {
-                MultiplierGraphing.Graph();
+                if (args.Length > 1 && args[1] == "unranked")
+                {
+                    Console.WriteLine("Graphing UNRANKED");
+                    MultiplierGraphing.Graph(false);
+                }
+                else
+                {
+                    MultiplierGraphing.Graph(true);
+                }
+
+            }
+            else if (args[0] == "test")
+            {
+                List<double> values = new List<double> {
+                    1,1,1,1,1,1,1,9,9,9
+                    };
+                double results = DifficultyCalculation.WeightedAverageOfValues(values, 0.3, 1, 0.1);
+                double results2 = DifficultyCalculation.WeightedAverageOfValues(values, 0.2, 1, 0.1);
+                Console.WriteLine($"Weighted: {results} Weighted: {results2} Mean: {values.Average()}");
             }
             else
             {

--- a/MuseMapalyzr/config-reader.cs
+++ b/MuseMapalyzr/config-reader.cs
@@ -3,23 +3,50 @@ namespace MuseMapalyzr
 {
     public class ConfigReader
     {
-        public static string GetConfigPath()
+        private static MuseMapalyzrConfig? _rankedConfig;
+        private static MuseMapalyzrConfig? _unrankedConfig;
+        public static string GetConfigPath(bool ranked = true)
         {
             string currentDirectory = Directory.GetCurrentDirectory();
-            string configFilePath = Path.Combine(currentDirectory, "config", "config.yaml");
+            string configFilePath;
+            if (ranked)
+            {
+                configFilePath = Path.Combine(currentDirectory, "config", "config.yaml");
+            }
+            else
+            {
+                configFilePath = Path.Combine(currentDirectory, "config", "unranked_config.yaml");
+            }
+
             return configFilePath;
         }
 
-        public static MuseMapalyzrConfig GetConfig()
+        private static MuseMapalyzrConfig DeserializeConfig(bool ranked)
         {
-            string yamlContent = File.ReadAllText(GetConfigPath());
+            string yamlContent = File.ReadAllText(GetConfigPath(ranked));
             var deserializer = new DeserializerBuilder().Build();
             MuseMapalyzrConfig config = deserializer.Deserialize<MuseMapalyzrConfig>(yamlContent);
             return config;
         }
 
+        public static MuseMapalyzrConfig GetConfig()
+        {
+            _rankedConfig ??= DeserializeConfig(true);
+            return _rankedConfig;
+        }
+
+        public static MuseMapalyzrConfig GetUnrankedConfig()
+        {
+            _unrankedConfig ??= DeserializeConfig(false);
+            return _unrankedConfig;
+        }
+
         public class MuseMapalyzrConfig
         {
+            public int NormalSizedMapThreshold { get; set; }
+            public double DensityTopProportion { get; set; }
+            public double DensityTopWeighting { get; set; }
+            public double DensityBottomWeighting { get; set; }
             public int PatternToleranceMs { get; set; }
             public int SegmentToleranceMs { get; set; }
             public double GetPatternWeightingTopPercentage { get; set; }

--- a/MuseMapalyzr/config-reader.cs
+++ b/MuseMapalyzr/config-reader.cs
@@ -47,6 +47,7 @@ namespace MuseMapalyzr
             public double DensityTopProportion { get; set; }
             public double DensityTopWeighting { get; set; }
             public double DensityBottomWeighting { get; set; }
+            public double DensitySingleStreamNPSCap { get; set; }
             public int PatternToleranceMs { get; set; }
             public int SegmentToleranceMs { get; set; }
             public double GetPatternWeightingTopPercentage { get; set; }

--- a/MuseMapalyzr/config-reader.cs
+++ b/MuseMapalyzr/config-reader.cs
@@ -78,10 +78,6 @@ namespace MuseMapalyzr
             public double NothingButTheoryUpBound { get; set; }
             public double NothingButTheoryLowClamp { get; set; }
             public double NothingButTheoryUpClamp { get; set; }
-            public double VaryingStreamsLowBound { get; set; }
-            public double VaryingStreamsUpBound { get; set; }
-            public double VaryingStreamsLowClamp { get; set; }
-            public double VaryingStreamsUpClamp { get; set; }
             public double ZigZagLowBound { get; set; }
             public double ZigZagUpBound { get; set; }
             public double ZigZagLowClamp { get; set; }
@@ -94,10 +90,6 @@ namespace MuseMapalyzr
             public double StreamUpBound { get; set; }
             public double StreamLowClamp { get; set; }
             public double StreamUpClamp { get; set; }
-            public double PatternStreamLengthLowBound { get; set; }
-            public double PatternStreamLengthUpBound { get; set; }
-            public double PatternStreamLengthLowClamp { get; set; }
-            public double PatternStreamLengthUpClamp { get; set; }
             public double ZigZagLengthLowBound { get; set; }
             public double ZigZagLengthUpBound { get; set; }
             public double ZigZagLengthLowClamp { get; set; }

--- a/MuseMapalyzr/config-reader.cs
+++ b/MuseMapalyzr/config-reader.cs
@@ -51,6 +51,9 @@ namespace MuseMapalyzr
             public double DensityTopWeighting { get; set; }
             public double DensityBottomWeighting { get; set; }
             public double DensitySingleStreamNPSCap { get; set; }
+            public double DensityFourStackNPSCap { get; set; }
+            public double DensityThreeStackNPSCap { get; set; }
+            public double DensityTwoStackNPSCap { get; set; }
             public int PatternToleranceMs { get; set; }
             public int SegmentToleranceMs { get; set; }
             public double GetPatternWeightingTopPercentage { get; set; }

--- a/MuseMapalyzr/config-reader.cs
+++ b/MuseMapalyzr/config-reader.cs
@@ -5,6 +5,9 @@ namespace MuseMapalyzr
     {
         private static MuseMapalyzrConfig? _rankedConfig;
         private static MuseMapalyzrConfig? _unrankedConfig;
+
+        public static bool Debug = true;
+
         public static string GetConfigPath(bool ranked = true)
         {
             string currentDirectory = Directory.GetCurrentDirectory();

--- a/MuseMapalyzr/config/config.yaml
+++ b/MuseMapalyzr/config/config.yaml
@@ -14,6 +14,9 @@ DensityTopProportion: 0.3
 DensityTopWeighting: 1
 DensityBottomWeighting: 0.3
 
+DensitySingleStreamNPSCap: 8
+
+
 # Tolerances
 PatternToleranceMs: 20
 SegmentToleranceMs: 10

--- a/MuseMapalyzr/config/config.yaml
+++ b/MuseMapalyzr/config/config.yaml
@@ -59,12 +59,6 @@ NothingButTheoryUpBound: 1.5
 NothingButTheoryLowClamp: 2.5
 NothingButTheoryUpClamp: 21.5
 
-# VaryingStreams
-VaryingStreamsLowBound: 1
-VaryingStreamsUpBound: 2
-VaryingStreamsLowClamp: 2.5
-VaryingStreamsUpClamp: 20.5
-
 # ZigZagMultiplier
 ZigZagLowBound: 1
 ZigZagUpBound: 2
@@ -73,23 +67,17 @@ ZigZagUpClamp: 18
 
 # EvenCircleMultiplier
 EvenCircleLowBound: 1
-EvenCircleUpBound: 1.55
+EvenCircleUpBound: 1.15
 
 # SkewedCircleMultiplier
 SkewedCircleLowBound: 1
-SkewedCircleUpBound: 1.75
+SkewedCircleUpBound: 1.25
 
 # StreamMultiplier
 StreamLowBound: 1
-StreamUpBound: 1.3
+StreamUpBound: 1.4
 StreamLowClamp: 5
 StreamUpClamp: 14
-
-# PatternStreamLengthMultiplier
-PatternStreamLengthLowBound: 1.025
-PatternStreamLengthUpBound: 1.1
-PatternStreamLengthLowClamp: 6.5
-PatternStreamLengthUpClamp: 20
 
 # ZigZagLengthMultiplier
 ZigZagLengthLowBound: 1
@@ -100,19 +88,19 @@ ZigZagLengthNpsThreshold: 17 # Slightly faster than EWF
 
 # FourStackMultiplier
 FourStackLowBound: 1.0
-FourStackUpBound: 1.3
+FourStackUpBound: 1.45
 FourStackLowClamp: 5
 FourStackUpClamp: 14
 
 # ThreeStackMultiplier
 ThreeStackLowBound: 1.0
-ThreeStackUpBound: 1.2
+ThreeStackUpBound: 1.35
 ThreeStackLowClamp: 5
 ThreeStackUpClamp: 14
 
 # TwoStackMultiplier
 TwoStackLowBound: 1.0
-TwoStackUpBound: 1.15
+TwoStackUpBound: 1.3
 TwoStackLowClamp: 5
 TwoStackUpClamp: 14
 

--- a/MuseMapalyzr/config/config.yaml
+++ b/MuseMapalyzr/config/config.yaml
@@ -75,7 +75,7 @@ SkewedCircleUpBound: 1.25
 
 # StreamMultiplier
 StreamLowBound: 1
-StreamUpBound: 1.4
+StreamUpBound: 1.35
 StreamLowClamp: 5
 StreamUpClamp: 14
 
@@ -88,7 +88,7 @@ ZigZagLengthNpsThreshold: 17 # Slightly faster than EWF
 
 # FourStackMultiplier
 FourStackLowBound: 1.0
-FourStackUpBound: 1.45
+FourStackUpBound: 1.4
 FourStackLowClamp: 5
 FourStackUpClamp: 14
 

--- a/MuseMapalyzr/config/config.yaml
+++ b/MuseMapalyzr/config/config.yaml
@@ -15,7 +15,9 @@ DensityTopWeighting: 1
 DensityBottomWeighting: 0.3
 
 DensitySingleStreamNPSCap: 8
-
+DensityFourStackNPSCap: 9
+DensityThreeStackNPSCap: 10
+DensityTwoStackNPSCap: 11
 
 # Tolerances
 PatternToleranceMs: 20

--- a/MuseMapalyzr/config/unranked_config.yaml
+++ b/MuseMapalyzr/config/unranked_config.yaml
@@ -27,7 +27,7 @@ GetPatternWeightingTopWeight: 0.9
 GetPatternWeightingBottomWeight: 0.1
 
 # Density Average
-SampleWindowSecs: 1 # Default 1
+SampleWindowSecs: 1 # Default 1 DO NOT CHANGE THIS LOL Since NPS calculations will be messed up
 MovingAvgWindow: 5 # Default 5
 
 # Interval NPS Thresholds

--- a/MuseMapalyzr/config/unranked_config.yaml
+++ b/MuseMapalyzr/config/unranked_config.yaml
@@ -60,12 +60,6 @@ NothingButTheoryUpBound: 1.5
 NothingButTheoryLowClamp: 2.5
 NothingButTheoryUpClamp: 21.5
 
-# VaryingStreams
-VaryingStreamsLowBound: 1
-VaryingStreamsUpBound: 2
-VaryingStreamsLowClamp: 2.5
-VaryingStreamsUpClamp: 20.5
-
 # ZigZagMultiplier
 ZigZagLowBound: 1
 ZigZagUpBound: 2
@@ -74,23 +68,17 @@ ZigZagUpClamp: 18
 
 # EvenCircleMultiplier
 EvenCircleLowBound: 1
-EvenCircleUpBound: 1.55
+EvenCircleUpBound: 1.15
 
 # SkewedCircleMultiplier
 SkewedCircleLowBound: 1
-SkewedCircleUpBound: 1.75
+SkewedCircleUpBound: 1.25
 
 # StreamMultiplier
 StreamLowBound: 1
-StreamUpBound: 1.3
+StreamUpBound: 1.5
 StreamLowClamp: 5
 StreamUpClamp: 14
-
-# PatternStreamLengthMultiplier
-PatternStreamLengthLowBound: 1.025
-PatternStreamLengthUpBound: 1.1
-PatternStreamLengthLowClamp: 6.5
-PatternStreamLengthUpClamp: 20
 
 # ZigZagLengthMultiplier
 ZigZagLengthLowBound: 1
@@ -101,19 +89,19 @@ ZigZagLengthNpsThreshold: 17 # Slightly faster than EWF
 
 # FourStackMultiplier
 FourStackLowBound: 1.0
-FourStackUpBound: 1.3
+FourStackUpBound: 1.45
 FourStackLowClamp: 5
 FourStackUpClamp: 14
 
 # ThreeStackMultiplier
 ThreeStackLowBound: 1.0
-ThreeStackUpBound: 1.2
+ThreeStackUpBound: 1.35
 ThreeStackLowClamp: 5
 ThreeStackUpClamp: 14
 
 # TwoStackMultiplier
 TwoStackLowBound: 1.0
-TwoStackUpBound: 1.15
+TwoStackUpBound: 1.3
 TwoStackLowClamp: 5
 TwoStackUpClamp: 14
 

--- a/MuseMapalyzr/config/unranked_config.yaml
+++ b/MuseMapalyzr/config/unranked_config.yaml
@@ -15,6 +15,8 @@ DensityTopProportion: 0.2
 DensityTopWeighting: 1.2
 DensityBottomWeighting: 0.1
 
+DensitySingleStreamNPSCap: 13
+
 # Tolerances
 PatternToleranceMs: 20
 SegmentToleranceMs: 10

--- a/MuseMapalyzr/config/unranked_config.yaml
+++ b/MuseMapalyzr/config/unranked_config.yaml
@@ -1,18 +1,19 @@
-###### RANKED ### RANKED ### RANKED ### RANKED ### RANKED ### RANKED ### RANKED #####
+###### UNRANKED ### UNRANKED ### UNRANKED ### UNRANKED ### UNRANKED ### UNRANKED ####
 #                                                                                   #
-#   This is the config file for RANKED difficulty calculation                       #
-#   This means that certain patterns though are difficult (extremely fast zigzags)  # 
-#   don't boost the difficulty as we want to discourage those types of maps         #                          
+#   This is the config file for UNRANKED difficulty calculation                     #
+#   This means that there is a less harsh cap on ZIG ZAGS and SINGLE LANE STREAMS   # 
 #                                                                                   #
 #####################################################################################
 
+# Note that some of these aren't used and the ranked config is used (e.g., sample window threshold etc.)
+
 # Normal Sized Map Threshold
-NormalSizedMapThreshold: 91 # Screw you TV-sized maps :)
+NormalSizedMapThreshold: 0
 
 # Density 
-DensityTopProportion: 0.3
-DensityTopWeighting: 1
-DensityBottomWeighting: 0.3
+DensityTopProportion: 0.2
+DensityTopWeighting: 1.2
+DensityBottomWeighting: 0.1
 
 # Tolerances
 PatternToleranceMs: 20
@@ -24,7 +25,7 @@ GetPatternWeightingTopWeight: 0.9
 GetPatternWeightingBottomWeight: 0.1
 
 # Density Average
-SampleWindowSecs: 1 # Default 1 DO NOT CHANGE THIS LOL Since NPS calculations will be messed up
+SampleWindowSecs: 1 # Default 1
 MovingAvgWindow: 5 # Default 5
 
 # Interval NPS Thresholds

--- a/MuseMapalyzr/config/unranked_config.yaml
+++ b/MuseMapalyzr/config/unranked_config.yaml
@@ -16,6 +16,9 @@ DensityTopWeighting: 1.2
 DensityBottomWeighting: 0.1
 
 DensitySingleStreamNPSCap: 13
+DensityFourStackNPSCap: 14
+DensityThreeStackNPSCap: 15
+DensityTwoStackNPSCap: 16
 
 # Tolerances
 PatternToleranceMs: 20

--- a/MuseMapalyzr/difficulty-calculation.cs
+++ b/MuseMapalyzr/difficulty-calculation.cs
@@ -485,7 +485,7 @@ namespace MuseMapalyzr
 
 
                     CustomLogger.Instance.PatternLog($"{pattern.PatternName,20} {rankedScore,10:F3} {unrankedScore,10:F3} {pattern.Segments.Count,10} {pattern.StartSample,18} {pattern.EndSample,18}");
-                    if (pattern.PatternName == Constants.Other)
+                    if (true)
                     {
                         CustomLogger.Instance.PatternLog(String.Format("\n{0,30} {1,10} {2,10} {3,10}", "Segment Name", "# Notes", "NPS", "Multiplier"));
 

--- a/MuseMapalyzr/difficulty-calculation.cs
+++ b/MuseMapalyzr/difficulty-calculation.cs
@@ -440,11 +440,11 @@ namespace MuseMapalyzr
                     CustomLogger.Instance.PatternLog($"{pattern.PatternName,20} {rankedScore,10:F3} {unrankedScore,10:F3} {pattern.Segments.Count,10} {pattern.StartSample,18} {pattern.EndSample,18}");
                     if (pattern.PatternName == Constants.Other)
                     {
-                        CustomLogger.Instance.PatternLog(String.Format("\n{0,30} {1,10} {2,10}", "Segment Name", "# Notes", "NPS"));
+                        CustomLogger.Instance.PatternLog(String.Format("\n{0,30} {1,10} {2,10} {3,10}", "Segment Name", "# Notes", "NPS", "Multiplier"));
 
                         foreach (Segment seg in pattern.Segments)
                         {
-                            CustomLogger.Instance.PatternLog($"{seg.SegmentName,30} {seg.Notes.Count,10} {seg.NotesPerSecond,10:F3}");
+                            CustomLogger.Instance.PatternLog($"{seg.SegmentName,30} {seg.Notes.Count,10} {seg.NotesPerSecond,10:F3} {seg.Multiplier,10:F3}");
 
                         }
                         CustomLogger.Instance.PatternLog("");

--- a/MuseMapalyzr/difficulty-calculation.cs
+++ b/MuseMapalyzr/difficulty-calculation.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace MuseMapalyzr
 {
     public class DifficultyCalculation
@@ -99,6 +101,11 @@ namespace MuseMapalyzr
         )
         {
 
+            using (StreamWriter writer = new StreamWriter("test.log", false, Encoding.UTF8))
+            {
+                writer.WriteLine("Hello");
+            }
+
             int sectionThreshold = sectionThresholdSeconds * sampleRate;
             double songStartSamples = notes.Min(note => note.SampleTime);
             double songDurationSamples = notes.Max(note => note.SampleTime);
@@ -136,11 +143,11 @@ namespace MuseMapalyzr
                         Segment? foundSegment = FindSegmentFromStartNote(note, streamSegments);
                         if (foundSegment == null)
                         {
-                            Console.WriteLine("OOF adding anyways");
+                            CustomLogger.Instance.Warning($"Didn't actually find a segment.. Adding the note anyways SampleTime{note.SampleTime}");
                             sections[sectionIndex].Add(note);
                             lastAddedNote = note;
 
-                            if (skipped > 0) Console.WriteLine($"Skipped {skipped}");
+                            if (skipped > 0) CustomLogger.Instance.Debug($"Found segment == null: Skipped {skipped}");
                             skipped = 0;
                         }
                         else
@@ -153,8 +160,8 @@ namespace MuseMapalyzr
                             // Check if Segment NPS is above the threshold or not
                             if (foundSegment.NotesPerSecond > npsCap)
                             {
-                                Console.WriteLine($"Found Segment. Count: ({foundSegment.Notes.Count}) NPS: {foundSegment.NotesPerSecond}");
-                                Console.WriteLine($"{segmentNotes.First().SampleTime} -> {segmentNotes.Last().SampleTime}");
+                                CustomLogger.Instance.Debug($"Found Segment. Count: ({foundSegment.Notes.Count}) NPS: {foundSegment.NotesPerSecond}");
+                                CustomLogger.Instance.Debug($"{segmentNotes.First().SampleTime} -> {segmentNotes.Last().SampleTime}");
 
                                 int notesAdded = 0;
 
@@ -174,7 +181,7 @@ namespace MuseMapalyzr
                                         sections[sectionIndex].Add(tempNote);
                                         lastAddedNote = tempNote;
                                         notesAdded++;
-                                        // Console.WriteLine($"Adding note: {tempNote.SampleTime}");
+                                        // CustomLogger.Instance.Debug($"Adding note: {tempNote.SampleTime}");
                                     }
                                     else
                                     {
@@ -185,10 +192,10 @@ namespace MuseMapalyzr
                                             sections[sectionIndex].Add(finalNote);
                                             lastAddedNote = finalNote;
                                             notesAdded++;
-                                            // Console.WriteLine($"Added final note: {finalNote.SampleTime}");
+                                            // CustomLogger.Instance.Debug($"Added final note: {finalNote.SampleTime}");
                                         }
                                         done = true;
-                                        Console.WriteLine($"Done: {notesAdded} added");
+                                        CustomLogger.Instance.Debug($"Done: {notesAdded} added");
                                     }
                                 }
                             }
@@ -205,7 +212,7 @@ namespace MuseMapalyzr
                     {
                         sections[sectionIndex].Add(note);
                         lastAddedNote = note;
-                        if (skipped > 0) Console.WriteLine($"Skipped {skipped}");
+                        if (skipped > 0) CustomLogger.Instance.Debug($"note.SampleTime > lastAddedNote.SampleTime: Skipped {skipped}");
                         skipped = 0;
 
                     }

--- a/MuseMapalyzr/difficulty-calculation.cs
+++ b/MuseMapalyzr/difficulty-calculation.cs
@@ -427,7 +427,7 @@ namespace MuseMapalyzr
             List<PatternScore> rankedPatternScores = new List<PatternScore>();
             List<PatternScore> unrankedPatternScores = new List<PatternScore>();
             // Console.WriteLine($"Checking {patterns.Count} Patterns");
-
+            CustomLogger.Instance.PatternLog(String.Format("\n{0,20} {1,10} {2,10} {3,10} {4,18} {5,18}", "Pattern Name", "Ranked", "Unranked", "# Segments", "Start SampleTime", "End SampleTime"));
             foreach (Pattern pattern in patterns)
             {
                 // Console.WriteLine($"----------{pattern.PatternName} {pattern.Segments.Count}----------");
@@ -435,6 +435,21 @@ namespace MuseMapalyzr
                 {
                     double rankedScore = pattern.CalculatePatternDifficulty(true);
                     double unrankedScore = pattern.CalculatePatternDifficulty(false);
+
+
+                    CustomLogger.Instance.PatternLog($"{pattern.PatternName,20} {rankedScore,10:F3} {unrankedScore,10:F3} {pattern.Segments.Count,10} {pattern.StartSample,18} {pattern.EndSample,18}");
+                    if (pattern.PatternName == Constants.Other)
+                    {
+                        CustomLogger.Instance.PatternLog(String.Format("\n{0,30} {1,10} {2,10}", "Segment Name", "# Notes", "NPS"));
+
+                        foreach (Segment seg in pattern.Segments)
+                        {
+                            CustomLogger.Instance.PatternLog($"{seg.SegmentName,30} {seg.Notes.Count,10} {seg.NotesPerSecond,10:F3}");
+
+                        }
+                        CustomLogger.Instance.PatternLog("");
+
+                    }
                     // Console.WriteLine($"Pattern Difficulty Score: {score}");
                     rankedPatternScores.Add(
                         new PatternScore(

--- a/MuseMapalyzr/difficulty-calculation.cs
+++ b/MuseMapalyzr/difficulty-calculation.cs
@@ -474,17 +474,18 @@ namespace MuseMapalyzr
             List<PatternScore> rankedPatternScores = new List<PatternScore>();
             List<PatternScore> unrankedPatternScores = new List<PatternScore>();
             // Console.WriteLine($"Checking {patterns.Count} Patterns");
-            CustomLogger.Instance.PatternLog(String.Format("\n{0,20} {1,10} {2,10} {3,10} {4,18} {5,18}", "Pattern Name", "Ranked", "Unranked", "# Segments", "Start SampleTime", "End SampleTime"));
+            CustomLogger.Instance.PatternLog(String.Format("\n{0,20} {1,10} {2,18} {3,18}", "Pattern Name", "# Segments", "Start SampleTime", "End SampleTime"));
             foreach (Pattern pattern in patterns)
             {
                 // Console.WriteLine($"----------{pattern.PatternName} {pattern.Segments.Count}----------");
                 if (pattern.Segments != null && pattern.Segments.Count > 0) // check if pattern has segments
                 {
-                    double rankedScore = pattern.CalculatePatternDifficulty(true);
-                    double unrankedScore = pattern.CalculatePatternDifficulty(false);
+
+                    pattern.CalculatePatternDifficulty(true);
+                    pattern.CalculatePatternDifficulty(false);
 
 
-                    CustomLogger.Instance.PatternLog($"{pattern.PatternName,20} {rankedScore,10:F3} {unrankedScore,10:F3} {pattern.Segments.Count,10} {pattern.StartSample,18} {pattern.EndSample,18}");
+                    CustomLogger.Instance.PatternLog($"{pattern.PatternName,20} {pattern.Segments.Count,10} {pattern.StartSample,18} {pattern.EndSample,18}");
                     if (true)
                     {
                         CustomLogger.Instance.PatternLog(String.Format("\n{0,30} {1,10} {2,10} {3,10} {4,10}", "Segment Name", "# Notes", "NPS", "R Multi", "UR Multi"));
@@ -497,70 +498,21 @@ namespace MuseMapalyzr
                         CustomLogger.Instance.PatternLog("");
 
                     }
-                    // Console.WriteLine($"Pattern Difficulty Score: {score}");
-                    rankedPatternScores.Add(
-                        new PatternScore(
-                            pattern.PatternName,
-                            rankedScore,
-                            pattern.HasIntervalSegment,
-                            pattern.TotalNotes
-                        )
-                    );
-                    unrankedPatternScores.Add(
-                        new PatternScore(
-                            pattern.PatternName,
-                            unrankedScore,
-                            pattern.HasIntervalSegment,
-                            pattern.TotalNotes
-                        )
-                    );
                 }
             }
 
-            // Before, this was where pattern length multipliers were applied. 
-            // That wasn't working as intended so now it's just straight up the scores
-            // This is still here incase we want to look into that again.
             ScoreResults scoreResults = new ScoreResults();
 
-            foreach (PatternScore rps in rankedPatternScores)
+            foreach (Pattern pattern in patterns)
             {
-                scoreResults.RankedScores.Add(rps.Score);
-            }
-
-            foreach (PatternScore urps in unrankedPatternScores)
-            {
-                scoreResults.UnrankedScores.Add(urps.Score);
+                foreach (Segment segment in pattern.Segments)
+                {
+                    scoreResults.RankedScores.Add(segment.RankedMultiplier);
+                    scoreResults.UnrankedScores.Add(segment.UnrankedMultiplier);
+                }
             }
             return scoreResults;
         }
-
-        // Commented out as it wasn't working as intended and buffing/nerfing maps unintentionally
-        // public static List<double> ApplyMultiplierToPatternChunk(List<PatternScore> chunk)
-        // {
-        //     int totalNotes = chunk.Sum(ps => ps.TotalNotes);
-
-        //     double multiplier = 1;
-        //     if (chunk.Count > 2)
-        //     {
-        //         multiplier = PatternMultiplier.PatternStreamLengthMultiplier(totalNotes);
-        //     }
-
-        //     List<double> multiplied = new List<double>();
-        //     foreach (PatternScore c_ps in chunk)
-        //     {
-        //         Console.WriteLine($"Chunk time: {c_ps.PatternName} {c_ps.TotalNotes} ... {multiplier} ... {c_ps.Score}");
-        //         double score = c_ps.PatternName != Constants.ZigZag ? c_ps.Score * multiplier : c_ps.Score;
-        //         multiplied.Add(score);
-        //         if (multiplier > 1)
-        //         {
-        //             Console.WriteLine($"Before: {c_ps.Score} AFter: {score}");
-
-        //         }
-        //     }
-
-
-        //     return multiplied;
-        // }
     }
 
 

--- a/MuseMapalyzr/difficulty-calculation.cs
+++ b/MuseMapalyzr/difficulty-calculation.cs
@@ -487,11 +487,11 @@ namespace MuseMapalyzr
                     CustomLogger.Instance.PatternLog($"{pattern.PatternName,20} {rankedScore,10:F3} {unrankedScore,10:F3} {pattern.Segments.Count,10} {pattern.StartSample,18} {pattern.EndSample,18}");
                     if (true)
                     {
-                        CustomLogger.Instance.PatternLog(String.Format("\n{0,30} {1,10} {2,10} {3,10}", "Segment Name", "# Notes", "NPS", "Multiplier"));
+                        CustomLogger.Instance.PatternLog(String.Format("\n{0,30} {1,10} {2,10} {3,10} {4,10}", "Segment Name", "# Notes", "NPS", "R Multi", "UR Multi"));
 
                         foreach (Segment seg in pattern.Segments)
                         {
-                            CustomLogger.Instance.PatternLog($"{seg.SegmentName,30} {seg.Notes.Count,10} {seg.NotesPerSecond,10:F3} {seg.Multiplier,10:F3}");
+                            CustomLogger.Instance.PatternLog($"{seg.SegmentName,30} {seg.Notes.Count,10} {seg.NotesPerSecond,10:F3} {seg.RankedMultiplier,10:F3} {seg.UnrankedMultiplier,10:F3}");
 
                         }
                         CustomLogger.Instance.PatternLog("");

--- a/MuseMapalyzr/entities.cs
+++ b/MuseMapalyzr/entities.cs
@@ -34,6 +34,8 @@ namespace MuseMapalyzr
 
         public double? TimeDifference { get; set; }
 
+        public double Multiplier { get; set; }
+
         public int SampleRate { get; set; } = Constants.DefaultSampleRate;
 
         public double NotesPerSecond

--- a/MuseMapalyzr/entities.cs
+++ b/MuseMapalyzr/entities.cs
@@ -78,7 +78,7 @@ namespace MuseMapalyzr
 
         public override string ToString()
         {
-            return $"{SegmentName} {Notes.Count} {TimeDifference}";
+            return $"{SegmentName} NC: {Notes.Count} TD: {TimeDifference} NPS: {NotesPerSecond} {Notes.First().SampleTime} -> {Notes.Last().SampleTime}";
         }
 
     }

--- a/MuseMapalyzr/entities.cs
+++ b/MuseMapalyzr/entities.cs
@@ -34,7 +34,8 @@ namespace MuseMapalyzr
 
         public double? TimeDifference { get; set; }
 
-        public double Multiplier { get; set; }
+        public double RankedMultiplier { get; set; }
+        public double UnrankedMultiplier { get; set; }
 
         public int SampleRate { get; set; } = Constants.DefaultSampleRate;
 

--- a/MuseMapalyzr/mapalyzr.cs
+++ b/MuseMapalyzr/mapalyzr.cs
@@ -76,7 +76,7 @@ namespace MuseMapalyzr
                     // Append OtherGroup if no other groups were appendable
                     if (OtherPattern.Segments.Count > 0)
                     {
-                        Patterns.Add(new OtherPattern(Constants.Other, OtherPattern.Segments, OtherPattern.StartSample, OtherPattern.EndSample));
+                        Patterns.Add(new OtherPattern(Constants.Other, OtherPattern.Segments, OtherPattern.SampleRate));
                     }
                     OtherPattern.ResetGroup(previousSegment, currentSegment);  // reset OtherGroup
 
@@ -148,8 +148,7 @@ namespace MuseMapalyzr
                     Pattern lastPatternCopy = new OtherPattern(
                         Constants.Other,
                         new List<Segment>(OtherPattern.Segments),
-                        OtherPattern.StartSample,
-                        OtherPattern.EndSample
+                        OtherPattern.SampleRate
                     );
                     Patterns.Add(lastPatternCopy);
                 }

--- a/MuseMapalyzr/multiplier-grapher.cs
+++ b/MuseMapalyzr/multiplier-grapher.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Windows.Forms;
+using OxyPlot.WindowsForms;
+using OxyPlot;
+using OxyPlot.Series;
+using OxyPlot.Legends;
+namespace MuseMapalyzr
+{
+    public class MultiplierGraphing
+    {
+        public static PlotModel GraphMethods()
+        {
+            PlotModel plotModel = new PlotModel
+            {
+                Title = "Multiplier vs Note Speed (NPS)",
+            };
+            Legend legend = new Legend { LegendTitle = "Patterns", LegendPosition = 0 };
+            plotModel.Legends.Add(legend);
+
+            int count = 1000;
+            double[] npsValues = new double[count];
+            double step = (50 - 1) / (double)count;
+
+            for (int i = 0; i < count; i++)
+            {
+                npsValues[i] = 1 + i * step;
+            }
+
+            AddLineSeries(plotModel, npsValues, PatternMultiplier.EvenCircleMultiplier, "Even Circle");
+            AddLineSeries(plotModel, npsValues, PatternMultiplier.SkewedCircleMultiplier, "Skewed Circle");
+            AddLineSeries(plotModel, npsValues, PatternMultiplier.ZigZagMultiplier, "Zig Zag");
+            AddLineSeries(plotModel, npsValues, PatternMultiplier.NothingButTheoryMultiplier, "Nothing But Theory");
+            AddLineSeries(plotModel, npsValues, PatternMultiplier.StreamMultiplier, "Stream");
+            AddLineSeries(plotModel, npsValues, PatternMultiplier.FourStackMultiplier, "4-Stacks");
+            AddLineSeries(plotModel, npsValues, PatternMultiplier.ThreeStackMultiplier, "3-Stacks");
+            AddLineSeries(plotModel, npsValues, PatternMultiplier.TwoStackMultiplier, "2-Stacks");
+            AddLineSeries(plotModel, npsValues, PatternMultiplier.VaryingStacksMultiplier, "Varying Stacks");
+
+
+            return plotModel;
+        }
+
+        private static void AddLineSeries(PlotModel model, double[] npsValues, Func<double, double> method, string label)
+        {
+            var lineSeries = new LineSeries { Title = label };
+
+            foreach (double nps in npsValues)
+            {
+                lineSeries.Points.Add(new DataPoint(nps, method(nps)));
+            }
+
+            model.Series.Add(lineSeries);
+        }
+
+        public static void Graph()
+        {
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            var form = new MyForm();
+            Application.Run(form); // This line actually shows the form
+        }
+
+        public partial class MyForm : Form
+        {
+            public MyForm()
+            {
+
+                var plot = new PlotView
+                {
+                    Model = GraphMethods(),
+                    Dock = DockStyle.Fill
+                };
+
+                Controls.Add(plot);
+            }
+        }
+    }
+
+}

--- a/MuseMapalyzr/multiplier-grapher.cs
+++ b/MuseMapalyzr/multiplier-grapher.cs
@@ -8,7 +8,7 @@ namespace MuseMapalyzr
 {
     public class MultiplierGraphing
     {
-        public static PlotModel GraphMethods()
+        public static PlotModel GraphMethods(bool ranked)
         {
             PlotModel plotModel = new PlotModel
             {
@@ -26,15 +26,15 @@ namespace MuseMapalyzr
                 npsValues[i] = 1 + i * step;
             }
 
-            AddLineSeries(plotModel, npsValues, PatternMultiplier.EvenCircleMultiplier, "Even Circle");
-            AddLineSeries(plotModel, npsValues, PatternMultiplier.SkewedCircleMultiplier, "Skewed Circle");
-            AddLineSeries(plotModel, npsValues, PatternMultiplier.ZigZagMultiplier, "Zig Zag");
-            AddLineSeries(plotModel, npsValues, PatternMultiplier.NothingButTheoryMultiplier, "Nothing But Theory");
-            AddLineSeries(plotModel, npsValues, PatternMultiplier.StreamMultiplier, "Stream");
-            AddLineSeries(plotModel, npsValues, PatternMultiplier.FourStackMultiplier, "4-Stacks");
-            AddLineSeries(plotModel, npsValues, PatternMultiplier.ThreeStackMultiplier, "3-Stacks");
-            AddLineSeries(plotModel, npsValues, PatternMultiplier.TwoStackMultiplier, "2-Stacks");
-            AddLineSeries(plotModel, npsValues, PatternMultiplier.VaryingStacksMultiplier, "Varying Stacks");
+            AddLineSeries(plotModel, npsValues, (nps) => PatternMultiplier.EvenCircleMultiplier(nps, ranked), "Even Circle");
+            AddLineSeries(plotModel, npsValues, (nps) => PatternMultiplier.SkewedCircleMultiplier(nps, ranked), "Skewed Circle");
+            AddLineSeries(plotModel, npsValues, (nps) => PatternMultiplier.ZigZagMultiplier(nps, ranked), "Zig Zag");
+            AddLineSeries(plotModel, npsValues, (nps) => PatternMultiplier.NothingButTheoryMultiplier(nps, ranked), "Nothing But Theory");
+            AddLineSeries(plotModel, npsValues, (nps) => PatternMultiplier.StreamMultiplier(nps, ranked), "Stream");
+            AddLineSeries(plotModel, npsValues, (nps) => PatternMultiplier.FourStackMultiplier(nps, ranked), "4-Stacks");
+            AddLineSeries(plotModel, npsValues, (nps) => PatternMultiplier.ThreeStackMultiplier(nps, ranked), "3-Stacks");
+            AddLineSeries(plotModel, npsValues, (nps) => PatternMultiplier.TwoStackMultiplier(nps, ranked), "2-Stacks");
+            AddLineSeries(plotModel, npsValues, (nps) => PatternMultiplier.VaryingStacksMultiplier(nps, ranked), "Varying Stacks");
 
 
             return plotModel;
@@ -52,22 +52,22 @@ namespace MuseMapalyzr
             model.Series.Add(lineSeries);
         }
 
-        public static void Graph()
+        public static void Graph(bool ranked)
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            var form = new MyForm();
+            var form = new MyForm(ranked);
             Application.Run(form); // This line actually shows the form
         }
 
         public partial class MyForm : Form
         {
-            public MyForm()
+            public MyForm(bool ranked)
             {
 
                 var plot = new PlotView
                 {
-                    Model = GraphMethods(),
+                    Model = GraphMethods(ranked),
                     Dock = DockStyle.Fill
                 };
 

--- a/MuseMapalyzr/musemapalyzr-csharp.csproj
+++ b/MuseMapalyzr/musemapalyzr-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>netcoreapp7.0-windows</TargetFramework>
     <RootNamespace>musemapalyzr_csharp</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/MuseMapalyzr/musemapalyzr-csharp.csproj
+++ b/MuseMapalyzr/musemapalyzr-csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <RootNamespace>musemapalyzr_csharp</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="OxyPlot.WindowsForms" Version="2.1.2" />
     <PackageReference Include="YamlDotNet" Version="13.1.1" />
     <None Update="config\config.yaml">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/MuseMapalyzr/pattern-multipliers.cs
+++ b/MuseMapalyzr/pattern-multipliers.cs
@@ -5,7 +5,14 @@ namespace MuseMapalyzr
 {
     public class PatternMultiplier
     {
-        private static MuseMapalyzrConfig conf = ConfigReader.GetConfig();
+        private static MuseMapalyzrConfig Conf = ConfigReader.GetConfig();
+        private static MuseMapalyzrConfig UnrankedConf = ConfigReader.GetUnrankedConfig();
+
+        private static MuseMapalyzrConfig GetRightConfig(bool ranked)
+        {
+            if (ranked) return Conf;
+            return UnrankedConf;
+        }
 
         private static double SmoothStep(double x)
         {
@@ -27,91 +34,91 @@ namespace MuseMapalyzr
             return Math.Max(min, Math.Min(max, value));
         }
 
-        public static double NothingButTheoryMultiplier(double nps)
+        public static double NothingButTheoryMultiplier(double nps, bool ranked)
         {
-            double lowerBound = conf.NothingButTheoryLowBound;
-            double upperBound = conf.NothingButTheoryUpBound;
-            double lowerClamp = conf.NothingButTheoryLowClamp;
-            double upperClamp = conf.NothingButTheoryUpClamp;
+            double lowerBound = GetRightConfig(ranked).NothingButTheoryLowBound;
+            double upperBound = GetRightConfig(ranked).NothingButTheoryUpBound;
+            double lowerClamp = GetRightConfig(ranked).NothingButTheoryLowClamp;
+            double upperClamp = GetRightConfig(ranked).NothingButTheoryUpClamp;
 
             double t = (nps - lowerClamp) / (upperClamp - lowerClamp);
             t = Clamp(t, 0, 1);
             return lowerBound + (upperBound - lowerBound) * SmoothStep(t);
         }
 
-        public static double VaryingStreams(double nps)
+        public static double VaryingStreams(double nps, bool ranked)
         {
-            double lowerBound = conf.VaryingStreamsLowBound;
-            double upperBound = conf.VaryingStreamsUpBound;
-            double lowerClamp = conf.VaryingStreamsLowClamp;
-            double upperClamp = conf.VaryingStreamsUpClamp;
+            double lowerBound = GetRightConfig(ranked).VaryingStreamsLowBound;
+            double upperBound = GetRightConfig(ranked).VaryingStreamsUpBound;
+            double lowerClamp = GetRightConfig(ranked).VaryingStreamsLowClamp;
+            double upperClamp = GetRightConfig(ranked).VaryingStreamsUpClamp;
 
             double t = (nps - lowerClamp) / (upperClamp - lowerClamp);
             t = Clamp(t, 0, 1);
             return lowerBound + (upperBound - lowerBound) * SmoothStep(t);
         }
 
-        public static double ZigZagMultiplier(double nps)
+        public static double ZigZagMultiplier(double nps, bool ranked)
         {
-            double lowerBound = conf.ZigZagLowBound;
-            double upperBound = conf.ZigZagUpBound;
-            double lowerClamp = conf.ZigZagLowClamp;
-            double upperClamp = conf.ZigZagUpClamp;
+            double lowerBound = GetRightConfig(ranked).ZigZagLowBound;
+            double upperBound = GetRightConfig(ranked).ZigZagUpBound;
+            double lowerClamp = GetRightConfig(ranked).ZigZagLowClamp;
+            double upperClamp = GetRightConfig(ranked).ZigZagUpClamp;
 
             double t = (nps - lowerClamp) / (upperClamp - lowerClamp);
             t = Clamp(t, 0, 1);
             return lowerBound + (upperBound - lowerBound) * EaseInCubic(t);
         }
 
-        public static double EvenCircleMultiplier(double nps)
+        public static double EvenCircleMultiplier(double nps, bool ranked)
         {
-            double lowerBound = conf.EvenCircleLowBound;
-            double upperBound = conf.EvenCircleUpBound;
+            double lowerBound = GetRightConfig(ranked).EvenCircleLowBound;
+            double upperBound = GetRightConfig(ranked).EvenCircleUpBound;
 
             double t = Clamp(nps / 30, 0, 1);
             return lowerBound + (upperBound - lowerBound) * EaseInOut(t);
         }
 
-        public static double SkewedCircleMultiplier(double nps)
+        public static double SkewedCircleMultiplier(double nps, bool ranked)
         {
-            double lowerBound = conf.SkewedCircleLowBound;
-            double upperBound = conf.SkewedCircleUpBound;
+            double lowerBound = GetRightConfig(ranked).SkewedCircleLowBound;
+            double upperBound = GetRightConfig(ranked).SkewedCircleUpBound;
 
             double t = Clamp(nps / 30, 0, 1);
             return lowerBound + (upperBound - lowerBound) * EaseInOut(t);
         }
 
-        public static double StreamMultiplier(double nps)
+        public static double StreamMultiplier(double nps, bool ranked)
         {
-            double lowerBound = conf.StreamLowBound;
-            double upperBound = conf.StreamUpBound;
-            double lowerClamp = conf.StreamLowClamp;
-            double upperClamp = conf.StreamUpClamp;
+            double lowerBound = GetRightConfig(ranked).StreamLowBound;
+            double upperBound = GetRightConfig(ranked).StreamUpBound;
+            double lowerClamp = GetRightConfig(ranked).StreamLowClamp;
+            double upperClamp = GetRightConfig(ranked).StreamUpClamp;
 
             double t = (nps - lowerClamp) / (upperClamp - lowerClamp);
             t = Clamp(t, 0, 1);
             return lowerBound + (upperBound - lowerBound) * SmoothStep(t);
         }
 
-        public static double PatternStreamLengthMultiplier(double numNotes)
+        public static double PatternStreamLengthMultiplier(double numNotes, bool ranked)
         {
-            double lowerBound = conf.PatternStreamLengthLowBound;
-            double upperBound = conf.PatternStreamLengthUpBound;
-            double lowerClamp = conf.PatternStreamLengthLowClamp;
-            double upperClamp = conf.PatternStreamLengthUpClamp;
+            double lowerBound = GetRightConfig(ranked).PatternStreamLengthLowBound;
+            double upperBound = GetRightConfig(ranked).PatternStreamLengthUpBound;
+            double lowerClamp = GetRightConfig(ranked).PatternStreamLengthLowClamp;
+            double upperClamp = GetRightConfig(ranked).PatternStreamLengthUpClamp;
 
             double t = (numNotes - lowerClamp) / (upperClamp - lowerClamp);
             t = Clamp(t, 0, 1);
             return lowerBound + (upperBound - lowerBound) * SmoothStep(t);
         }
 
-        public static double ZigZagLengthMultiplier(double numNotes, double nps)
+        public static double ZigZagLengthMultiplier(double numNotes, double nps, bool ranked)
         {
-            double lowerBound = conf.ZigZagLengthLowBound;
-            double upperBound = conf.ZigZagLengthUpBound;
-            double lowerClamp = conf.ZigZagLengthLowClamp;
-            double upperClamp = conf.ZigZagLengthUpClamp;
-            double npsThreshold = conf.ZigZagLengthNpsThreshold;
+            double lowerBound = GetRightConfig(ranked).ZigZagLengthLowBound;
+            double upperBound = GetRightConfig(ranked).ZigZagLengthUpBound;
+            double lowerClamp = GetRightConfig(ranked).ZigZagLengthLowClamp;
+            double upperClamp = GetRightConfig(ranked).ZigZagLengthUpClamp;
+            double npsThreshold = GetRightConfig(ranked).ZigZagLengthNpsThreshold;
 
             if (nps > npsThreshold)
             {
@@ -122,7 +129,7 @@ namespace MuseMapalyzr
             return 1;
         }
 
-        public static double NothingButTheoryLengthMultiplier(double numNotes, double multiplier)
+        public static double NothingButTheoryLengthMultiplier(double numNotes, double multiplier, bool ranked)
         {
             double lowerBound = 0;
             double upperBound = 1;
@@ -138,12 +145,12 @@ namespace MuseMapalyzr
             return 1 + newAddtional;
         }
 
-        public static double FourStackMultiplier(double nps)
+        public static double FourStackMultiplier(double nps, bool ranked)
         {
-            double lowerBound = conf.FourStackLowBound;
-            double upperBound = conf.FourStackUpBound;
-            double lowerClamp = conf.FourStackLowClamp;
-            double upperClamp = conf.FourStackUpClamp;
+            double lowerBound = GetRightConfig(ranked).FourStackLowBound;
+            double upperBound = GetRightConfig(ranked).FourStackUpBound;
+            double lowerClamp = GetRightConfig(ranked).FourStackLowClamp;
+            double upperClamp = GetRightConfig(ranked).FourStackUpClamp;
 
             double t = (nps - lowerClamp) / (upperClamp - lowerClamp);
             t = Math.Max(Math.Min(t, 1), 0);
@@ -151,36 +158,36 @@ namespace MuseMapalyzr
         }
 
 
-        public static double ThreeStackMultiplier(double nps)
+        public static double ThreeStackMultiplier(double nps, bool ranked)
         {
-            double lowerBound = conf.ThreeStackLowBound;
-            double upperBound = conf.ThreeStackUpBound;
-            double lowerClamp = conf.ThreeStackLowClamp;
-            double upperClamp = conf.ThreeStackUpClamp;
+            double lowerBound = GetRightConfig(ranked).ThreeStackLowBound;
+            double upperBound = GetRightConfig(ranked).ThreeStackUpBound;
+            double lowerClamp = GetRightConfig(ranked).ThreeStackLowClamp;
+            double upperClamp = GetRightConfig(ranked).ThreeStackUpClamp;
 
             double t = (nps - lowerClamp) / (upperClamp - lowerClamp);
             t = Math.Max(Math.Min(t, 1), 0);
             return lowerBound + (upperBound - lowerBound) * SmoothStep(t);
         }
 
-        public static double TwoStackMultiplier(double nps)
+        public static double TwoStackMultiplier(double nps, bool ranked)
         {
-            double lowerBound = conf.TwoStackLowBound;
-            double upperBound = conf.TwoStackUpBound;
-            double lowerClamp = conf.TwoStackLowClamp;
-            double upperClamp = conf.TwoStackUpClamp;
+            double lowerBound = GetRightConfig(ranked).TwoStackLowBound;
+            double upperBound = GetRightConfig(ranked).TwoStackUpBound;
+            double lowerClamp = GetRightConfig(ranked).TwoStackLowClamp;
+            double upperClamp = GetRightConfig(ranked).TwoStackUpClamp;
 
             double t = (nps - lowerClamp) / (upperClamp - lowerClamp);
             t = Math.Max(Math.Min(t, 1), 0);
             return lowerBound + (upperBound - lowerBound) * SmoothStep(t);
         }
 
-        public static double VaryingStacksMultiplier(double nps)
+        public static double VaryingStacksMultiplier(double nps, bool ranked)
         {
-            double lowerBound = conf.VaryingStacksLowBound;
-            double upperBound = conf.VaryingStacksUpBound;
-            double lowerClamp = conf.VaryingStacksLowClamp;
-            double upperClamp = conf.VaryingStacksUpClamp;
+            double lowerBound = GetRightConfig(ranked).VaryingStacksLowBound;
+            double upperBound = GetRightConfig(ranked).VaryingStacksUpBound;
+            double lowerClamp = GetRightConfig(ranked).VaryingStacksLowClamp;
+            double upperClamp = GetRightConfig(ranked).VaryingStacksUpClamp;
 
             double t = (nps - lowerClamp) / (upperClamp - lowerClamp);
             t = Math.Max(Math.Min(t, 1), 0);

--- a/MuseMapalyzr/pattern-multipliers.cs
+++ b/MuseMapalyzr/pattern-multipliers.cs
@@ -46,17 +46,6 @@ namespace MuseMapalyzr
             return lowerBound + (upperBound - lowerBound) * SmoothStep(t);
         }
 
-        public static double VaryingStreams(double nps, bool ranked)
-        {
-            double lowerBound = GetRightConfig(ranked).VaryingStreamsLowBound;
-            double upperBound = GetRightConfig(ranked).VaryingStreamsUpBound;
-            double lowerClamp = GetRightConfig(ranked).VaryingStreamsLowClamp;
-            double upperClamp = GetRightConfig(ranked).VaryingStreamsUpClamp;
-
-            double t = (nps - lowerClamp) / (upperClamp - lowerClamp);
-            t = Clamp(t, 0, 1);
-            return lowerBound + (upperBound - lowerBound) * SmoothStep(t);
-        }
 
         public static double ZigZagMultiplier(double nps, bool ranked)
         {
@@ -96,18 +85,6 @@ namespace MuseMapalyzr
             double upperClamp = GetRightConfig(ranked).StreamUpClamp;
 
             double t = (nps - lowerClamp) / (upperClamp - lowerClamp);
-            t = Clamp(t, 0, 1);
-            return lowerBound + (upperBound - lowerBound) * SmoothStep(t);
-        }
-
-        public static double PatternStreamLengthMultiplier(double numNotes, bool ranked)
-        {
-            double lowerBound = GetRightConfig(ranked).PatternStreamLengthLowBound;
-            double upperBound = GetRightConfig(ranked).PatternStreamLengthUpBound;
-            double lowerClamp = GetRightConfig(ranked).PatternStreamLengthLowClamp;
-            double upperClamp = GetRightConfig(ranked).PatternStreamLengthUpClamp;
-
-            double t = (numNotes - lowerClamp) / (upperClamp - lowerClamp);
             t = Clamp(t, 0, 1);
             return lowerBound + (upperBound - lowerBound) * SmoothStep(t);
         }

--- a/MuseMapalyzr/patterns/concrete-patterns.cs
+++ b/MuseMapalyzr/patterns/concrete-patterns.cs
@@ -3,7 +3,7 @@ namespace MuseMapalyzr
     public class EvenCirclesGroup : Pattern
     {
         public EvenCirclesGroup(string patternName, List<Segment> segments, int startSample = 0, int endSample = 0, int sampleRate = 0)
-            : base(patternName, segments, startSample, endSample, sampleRate)
+            : base(patternName, segments, sampleRate)
         {
             SetCheckSegmentStrategy(new EvenCirclesCheckSegment(this));
             SetIsAppendableStrategy(new EvenCirclesIsAppendable(this));
@@ -13,7 +13,7 @@ namespace MuseMapalyzr
         }
         public override Pattern CreateCopy()
         {
-            return new EvenCirclesGroup(PatternName, Segments, StartSample, EndSample, SampleRate);
+            return new EvenCirclesGroup(PatternName, Segments, SampleRate);
         }
 
     }
@@ -22,7 +22,7 @@ namespace MuseMapalyzr
     public class SkewedCirclesGroup : Pattern
     {
         public SkewedCirclesGroup(string patternName, List<Segment> segments, int startSample = 0, int endSample = 0, int sampleRate = 0)
-            : base(patternName, segments, startSample, endSample, sampleRate)
+            : base(patternName, segments, sampleRate)
         {
             SetCheckSegmentStrategy(new SkewedCirclesCheckSegment(this));
             SetIsAppendableStrategy(new SkewedCirclesIsAppendable(this));
@@ -32,14 +32,14 @@ namespace MuseMapalyzr
         }
         public override Pattern CreateCopy()
         {
-            return new SkewedCirclesGroup(PatternName, Segments, StartSample, EndSample, SampleRate);
+            return new SkewedCirclesGroup(PatternName, Segments, SampleRate);
         }
     }
 
     public class NothingButTheoryGroup : Pattern
     {
         public NothingButTheoryGroup(string patternName, List<Segment> segments, int startSample = 0, int endSample = 0, int sampleRate = 0)
-            : base(patternName, segments, startSample, endSample, sampleRate)
+            : base(patternName, segments, sampleRate)
         {
             SetCheckSegmentStrategy(new NothingButTheoryCheckSegment(this));
             SetIsAppendableStrategy(new NothingButTheoryIsAppendable(this));
@@ -49,14 +49,14 @@ namespace MuseMapalyzr
         }
         public override Pattern CreateCopy()
         {
-            return new NothingButTheoryGroup(PatternName, Segments, StartSample, EndSample, SampleRate);
+            return new NothingButTheoryGroup(PatternName, Segments, SampleRate);
         }
     }
 
     public class SlowStretchPattern : Pattern
     {
         public SlowStretchPattern(string patternName, List<Segment> segments, int startSample = 0, int endSample = 0, int sampleRate = 0)
-            : base(patternName, segments, startSample, endSample, sampleRate)
+            : base(patternName, segments, sampleRate)
         {
             SetCheckSegmentStrategy(new SlowStretchCheckSegment(this));
             SetIsAppendableStrategy(new SlowStretchIsAppendable(this));
@@ -66,14 +66,14 @@ namespace MuseMapalyzr
         }
         public override Pattern CreateCopy()
         {
-            return new SlowStretchPattern(PatternName, Segments, StartSample, EndSample, SampleRate);
+            return new SlowStretchPattern(PatternName, Segments, SampleRate);
         }
     }
 
     public class VaryingStacksPattern : Pattern
     {
         public VaryingStacksPattern(string patternName, List<Segment> segments, int startSample = 0, int endSample = 0, int sampleRate = 0)
-            : base(patternName, segments, startSample, endSample, sampleRate)
+            : base(patternName, segments, sampleRate)
         {
             SetCheckSegmentStrategy(new VaryingStacksCheckSegment(this));
             SetIsAppendableStrategy(new VaryingStacksIsAppendable(this));
@@ -83,14 +83,14 @@ namespace MuseMapalyzr
         }
         public override Pattern CreateCopy()
         {
-            return new VaryingStacksPattern(PatternName, Segments, StartSample, EndSample, SampleRate);
+            return new VaryingStacksPattern(PatternName, Segments, SampleRate);
         }
     }
 
     public class OtherPattern : Pattern
     {
         public OtherPattern(string patternName, List<Segment> segments, int startSample = 0, int endSample = 0, int sampleRate = 0)
-            : base(patternName, segments, startSample, endSample, sampleRate)
+            : base(patternName, segments, sampleRate)
         {
             SetCheckSegmentStrategy(new OtherCheckSegment(this));
             SetIsAppendableStrategy(new OtherIsAppendable(this));
@@ -100,7 +100,7 @@ namespace MuseMapalyzr
         }
         public override Pattern CreateCopy()
         {
-            return new OtherPattern(PatternName, Segments, StartSample, EndSample, SampleRate);
+            return new OtherPattern(PatternName, Segments, SampleRate);
         }
     }
 

--- a/MuseMapalyzr/patterns/patterns.cs
+++ b/MuseMapalyzr/patterns/patterns.cs
@@ -273,6 +273,8 @@ namespace MuseMapalyzr
 
             double final = (VariationWeighting * variationMultiplier) + (PatternWeighting * patternMultiplier);
 
+            if (PatternName != Constants.Other) SetSegmentsMultiplier(final);
+
             return final;
         }
 
@@ -326,6 +328,11 @@ namespace MuseMapalyzr
         public double CalcPatternLengthMultiplier()
         {
             return CalcPatternLengthMultiplierStrategy.CalcPatternLengthMultiplier();
+        }
+
+        public void SetSegmentsMultiplier(double multiplier)
+        {
+            CalcPatternMultiplierStrategy.SetSegmentsMultiplier(multiplier);
         }
 
         public override string ToString()

--- a/MuseMapalyzr/patterns/patterns.cs
+++ b/MuseMapalyzr/patterns/patterns.cs
@@ -8,8 +8,20 @@ namespace MuseMapalyzr
     {
         public string PatternName { get; set; }
         public List<Segment> Segments { get; set; }
-        public int StartSample { get; set; }
-        public int EndSample { get; set; }
+        public double StartSample
+        {
+            get
+            {
+                return Segments.First().Notes.First().SampleTime;
+            }
+        }
+        public double EndSample
+        {
+            get
+            {
+                return Segments.Last().Notes.Last().SampleTime;
+            }
+        }
         public bool IsActive { get; set; }
         public int SampleRate { get; set; }
         public int Tolerance { get; set; }
@@ -70,12 +82,11 @@ namespace MuseMapalyzr
             }
         }
 
-        public Pattern(string patternName, List<Segment> segments, int startSample = 0, int endSample = 0, int sampleRate = 0)
+        public Pattern(string patternName, List<Segment> segments, int sampleRate)
         {
             PatternName = patternName;
             Segments = segments;
-            StartSample = startSample;
-            EndSample = endSample;
+
             IsActive = true;
             if (sampleRate == 0)
             {
@@ -104,7 +115,7 @@ namespace MuseMapalyzr
 
         public virtual Pattern CreateCopy()
         {
-            return new Pattern(PatternName, Segments, StartSample, EndSample);
+            return new Pattern(PatternName, Segments, SampleRate);
         }
 
         public Dictionary<string, int> GetSegmentTypeCounts(List<string> segmentNames)

--- a/MuseMapalyzr/patterns/patterns.cs
+++ b/MuseMapalyzr/patterns/patterns.cs
@@ -273,7 +273,7 @@ namespace MuseMapalyzr
 
             double final = (VariationWeighting * variationMultiplier) + (PatternWeighting * patternMultiplier);
 
-            if (PatternName != Constants.Other) SetSegmentsMultiplier(final);
+            if (PatternName != Constants.Other) SetSegmentsMultiplier(final, ranked);
 
             return final;
         }
@@ -330,9 +330,9 @@ namespace MuseMapalyzr
             return CalcPatternLengthMultiplierStrategy.CalcPatternLengthMultiplier();
         }
 
-        public void SetSegmentsMultiplier(double multiplier)
+        public void SetSegmentsMultiplier(double multiplier, bool ranked)
         {
-            CalcPatternMultiplierStrategy.SetSegmentsMultiplier(multiplier);
+            CalcPatternMultiplierStrategy.SetSegmentsMultiplier(multiplier, ranked);
         }
 
         public override string ToString()

--- a/MuseMapalyzr/patterns/patterns.cs
+++ b/MuseMapalyzr/patterns/patterns.cs
@@ -264,7 +264,7 @@ namespace MuseMapalyzr
             }
         }
 
-        public double CalculatePatternDifficulty(bool ranked)
+        public void CalculatePatternDifficulty(bool ranked)
         {
 
             double variationMultiplier = CalcVariationScore();
@@ -274,8 +274,6 @@ namespace MuseMapalyzr
             double final = (VariationWeighting * variationMultiplier) + (PatternWeighting * patternMultiplier);
 
             if (PatternName != Constants.Other) SetSegmentsMultiplier(final, ranked);
-
-            return final;
         }
 
 

--- a/MuseMapalyzr/patterns/patterns.cs
+++ b/MuseMapalyzr/patterns/patterns.cs
@@ -253,11 +253,12 @@ namespace MuseMapalyzr
             }
         }
 
-        public double CalculatePatternDifficulty()
+        public double CalculatePatternDifficulty(bool ranked)
         {
 
             double variationMultiplier = CalcVariationScore();
-            double patternMultiplier = CalcPatternMultiplier();
+            double patternMultiplier = CalcPatternMultiplier(ranked);
+            // Console.WriteLine($"Ranked {ranked} {patternMultiplier}");
 
             double final = (VariationWeighting * variationMultiplier) + (PatternWeighting * patternMultiplier);
 
@@ -306,9 +307,9 @@ namespace MuseMapalyzr
             return CalcVariationScoreStrategy.CalcVariationScore();
         }
 
-        public double CalcPatternMultiplier()
+        public double CalcPatternMultiplier(bool ranked)
         {
-            return CalcPatternMultiplierStrategy.CalcPatternMultiplier();
+            return CalcPatternMultiplierStrategy.CalcPatternMultiplier(ranked);
         }
 
         public double CalcPatternLengthMultiplier()

--- a/MuseMapalyzr/strategies/default-strategy.cs
+++ b/MuseMapalyzr/strategies/default-strategy.cs
@@ -72,7 +72,7 @@ namespace MuseMapalyzr
     {
         public DefaultCalcPatternMultiplier(Pattern pattern) : base(pattern) { }
 
-        public override double CalcPatternMultiplier()
+        public override double CalcPatternMultiplier(bool ranked)
         {
             return 1;
         }

--- a/MuseMapalyzr/strategies/even-circles.cs
+++ b/MuseMapalyzr/strategies/even-circles.cs
@@ -94,10 +94,10 @@ namespace MuseMapalyzr
     {
         public EvenCirclesCalcPatternMultiplier(Pattern pattern) : base(pattern) { }
 
-        public override double CalcPatternMultiplier()
+        public override double CalcPatternMultiplier(bool ranked)
         {
             double nps = Pattern.Segments[0].NotesPerSecond;  // Even Circle should have consistent NPS
-            double multiplier = PatternMultiplier.EvenCircleMultiplier(nps);  // You'll need to define the EvenCircleMultiplier method
+            double multiplier = PatternMultiplier.EvenCircleMultiplier(nps, ranked);  // You'll need to define the EvenCircleMultiplier method
             // Console.WriteLine($"EvenCirclesCalcPatternMultiplier: {multiplier}");
             return multiplier;
         }

--- a/MuseMapalyzr/strategies/nothing-but-theory.cs
+++ b/MuseMapalyzr/strategies/nothing-but-theory.cs
@@ -150,13 +150,13 @@ namespace MuseMapalyzr
     public class NothingButTheoryCalcPatternMultiplier : CalcPatternMultiplierStrategy
     {
         public NothingButTheoryCalcPatternMultiplier(Pattern pattern) : base(pattern) { }
-        public override double CalcPatternMultiplier()
+        public override double CalcPatternMultiplier(bool ranked)
         {
             double nps = Pattern.Segments[0].NotesPerSecond;
-            double multiplier = PatternMultiplier.NothingButTheoryMultiplier(nps);
+            double multiplier = PatternMultiplier.NothingButTheoryMultiplier(nps, ranked);
             // NBT can spike difficulties when it is a relatively fast but short as it maxes out the weighting
             // So, apply a weighting based on how many notes.
-            double newMultiplier = PatternMultiplier.NothingButTheoryLengthMultiplier(Pattern.TotalNotes, multiplier);
+            double newMultiplier = PatternMultiplier.NothingButTheoryLengthMultiplier(Pattern.TotalNotes, multiplier, ranked);
             // Console.WriteLine($"NothingButTheoryCalcPatternMultiplier: {multiplier} (NEW: {newMultiplier})| NPS: {nps} | Notes: {Pattern.TotalNotes}");
             return newMultiplier;
         }

--- a/MuseMapalyzr/strategies/other.cs
+++ b/MuseMapalyzr/strategies/other.cs
@@ -37,45 +37,53 @@ namespace MuseMapalyzr
     {
         public OtherCalcPatternMultiplier(Pattern pattern) : base(pattern) { }
 
-        public override double CalcPatternMultiplier()
+        public override double CalcPatternMultiplier(bool ranked)
         {
             // Other Patterns are calculated based on the weighted average
             // of the segment difficulties within the Other pattern.
             List<double> multipliers = new List<double>();
+
+            var conf = ConfigReader.GetConfig();
+            if (!ranked)
+            {
+                conf = ConfigReader.GetUnrankedConfig();
+            }
+
 
             foreach (var segment in Pattern.Segments)
             {
                 switch (segment.SegmentName)
                 {
                     case Constants.Switch:
-                        multipliers.Add(ConfigReader.GetConfig().OtherSwitchMultiplier);
+                        multipliers.Add(conf.OtherSwitchMultiplier);
                         break;
                     case Constants.ZigZag:
                         // Zig zags are special as they can have many notes in them.
-                        double zigZagMultiplier = PatternMultiplier.ZigZagMultiplier(segment.NotesPerSecond);
-                        double zigZagLengthMultiplier = PatternMultiplier.ZigZagLengthMultiplier(segment.Notes.Count, segment.NotesPerSecond);
+                        double zigZagMultiplier = PatternMultiplier.ZigZagMultiplier(segment.NotesPerSecond, ranked);
+                        double zigZagLengthMultiplier = PatternMultiplier.ZigZagLengthMultiplier(segment.Notes.Count, segment.NotesPerSecond, ranked);
                         multipliers.Add(zigZagMultiplier * zigZagLengthMultiplier);
                         break;
                     case Constants.TwoStack:
-                        multipliers.Add(PatternMultiplier.TwoStackMultiplier(segment.NotesPerSecond));
+                        multipliers.Add(PatternMultiplier.TwoStackMultiplier(segment.NotesPerSecond, ranked));
                         break;
                     case Constants.ThreeStack:
-                        multipliers.Add(PatternMultiplier.ThreeStackMultiplier(segment.NotesPerSecond));
+                        multipliers.Add(PatternMultiplier.ThreeStackMultiplier(segment.NotesPerSecond, ranked));
                         break;
                     case Constants.FourStack:
-                        multipliers.Add(PatternMultiplier.FourStackMultiplier(segment.NotesPerSecond));
+                        multipliers.Add(PatternMultiplier.FourStackMultiplier(segment.NotesPerSecond, ranked));
                         break;
                     case Constants.SingleStreams:
-                        multipliers.Add(PatternMultiplier.StreamMultiplier(segment.NotesPerSecond));
+                        multipliers.Add(PatternMultiplier.StreamMultiplier(segment.NotesPerSecond, ranked));
                         break;
                     case Constants.ShortInterval:
-                        multipliers.Add(ConfigReader.GetConfig().OtherShortIntMultiplier);
+
+                        multipliers.Add(conf.OtherShortIntMultiplier);
                         break;
                     case Constants.MedInterval:
-                        multipliers.Add(ConfigReader.GetConfig().OtherMedIntMultiplier);
+                        multipliers.Add(conf.OtherMedIntMultiplier);
                         break;
                     case Constants.LongInterval:
-                        multipliers.Add(ConfigReader.GetConfig().OtherLongIntMultiplier);
+                        multipliers.Add(conf.OtherLongIntMultiplier);
                         break;
                     default:
                         multipliers.Add(1);

--- a/MuseMapalyzr/strategies/other.cs
+++ b/MuseMapalyzr/strategies/other.cs
@@ -52,43 +52,46 @@ namespace MuseMapalyzr
 
             foreach (var segment in Pattern.Segments)
             {
+                double multiplier = 1;
                 switch (segment.SegmentName)
                 {
                     case Constants.Switch:
-                        multipliers.Add(conf.OtherSwitchMultiplier);
+                        multiplier = conf.OtherSwitchMultiplier;
                         break;
                     case Constants.ZigZag:
                         // Zig zags are special as they can have many notes in them.
                         double zigZagMultiplier = PatternMultiplier.ZigZagMultiplier(segment.NotesPerSecond, ranked);
                         double zigZagLengthMultiplier = PatternMultiplier.ZigZagLengthMultiplier(segment.Notes.Count, segment.NotesPerSecond, ranked);
-                        multipliers.Add(zigZagMultiplier * zigZagLengthMultiplier);
+                        multiplier = zigZagMultiplier * zigZagLengthMultiplier;
                         break;
                     case Constants.TwoStack:
-                        multipliers.Add(PatternMultiplier.TwoStackMultiplier(segment.NotesPerSecond, ranked));
+                        multiplier = PatternMultiplier.TwoStackMultiplier(segment.NotesPerSecond, ranked);
                         break;
                     case Constants.ThreeStack:
-                        multipliers.Add(PatternMultiplier.ThreeStackMultiplier(segment.NotesPerSecond, ranked));
+                        multiplier = PatternMultiplier.ThreeStackMultiplier(segment.NotesPerSecond, ranked);
                         break;
                     case Constants.FourStack:
-                        multipliers.Add(PatternMultiplier.FourStackMultiplier(segment.NotesPerSecond, ranked));
+                        multiplier = PatternMultiplier.FourStackMultiplier(segment.NotesPerSecond, ranked);
                         break;
                     case Constants.SingleStreams:
-                        multipliers.Add(PatternMultiplier.StreamMultiplier(segment.NotesPerSecond, ranked));
+                        multiplier = PatternMultiplier.StreamMultiplier(segment.NotesPerSecond, ranked);
                         break;
                     case Constants.ShortInterval:
-
-                        multipliers.Add(conf.OtherShortIntMultiplier);
+                        multiplier = conf.OtherShortIntMultiplier;
                         break;
                     case Constants.MedInterval:
-                        multipliers.Add(conf.OtherMedIntMultiplier);
+                        multiplier = conf.OtherMedIntMultiplier;
                         break;
                     case Constants.LongInterval:
-                        multipliers.Add(conf.OtherLongIntMultiplier);
+                        multiplier = conf.OtherLongIntMultiplier;
                         break;
                     default:
-                        multipliers.Add(1);
+                        multipliers.Add(multiplier);
                         break;
                 }
+                multipliers.Add(multiplier);
+                segment.Multiplier = multiplier;
+
             }
 
             // If other has quite a few patterns and notes, then higher weighting to the harder patterns

--- a/MuseMapalyzr/strategies/other.cs
+++ b/MuseMapalyzr/strategies/other.cs
@@ -90,7 +90,15 @@ namespace MuseMapalyzr
                         break;
                 }
                 multipliers.Add(multiplier);
-                segment.Multiplier = multiplier;
+                if (ranked)
+                {
+                    segment.RankedMultiplier = multiplier;
+
+                }
+                else
+                {
+                    segment.UnrankedMultiplier = multiplier;
+                }
 
             }
 

--- a/MuseMapalyzr/strategies/pattern-strategies.cs
+++ b/MuseMapalyzr/strategies/pattern-strategies.cs
@@ -48,11 +48,18 @@ namespace MuseMapalyzr
 
         public abstract double CalcPatternMultiplier(bool ranked);
 
-        public void SetSegmentsMultiplier(double multiplier)
+        public void SetSegmentsMultiplier(double multiplier, bool ranked)
         {
             foreach (Segment segment in Pattern.Segments)
             {
-                segment.Multiplier = multiplier;
+                if (ranked)
+                {
+                    segment.RankedMultiplier = multiplier;
+                }
+                else
+                {
+                    segment.UnrankedMultiplier = multiplier;
+                }
             }
         }
     }

--- a/MuseMapalyzr/strategies/pattern-strategies.cs
+++ b/MuseMapalyzr/strategies/pattern-strategies.cs
@@ -47,6 +47,14 @@ namespace MuseMapalyzr
         }
 
         public abstract double CalcPatternMultiplier(bool ranked);
+
+        public void SetSegmentsMultiplier(double multiplier)
+        {
+            foreach (Segment segment in Pattern.Segments)
+            {
+                segment.Multiplier = multiplier;
+            }
+        }
     }
 
     public abstract class CalcPatternLengthMultiplierStrategy

--- a/MuseMapalyzr/strategies/pattern-strategies.cs
+++ b/MuseMapalyzr/strategies/pattern-strategies.cs
@@ -46,7 +46,7 @@ namespace MuseMapalyzr
             Pattern = pattern;
         }
 
-        public abstract double CalcPatternMultiplier();
+        public abstract double CalcPatternMultiplier(bool ranked);
     }
 
     public abstract class CalcPatternLengthMultiplierStrategy

--- a/MuseMapalyzr/strategies/skewed-circles.cs
+++ b/MuseMapalyzr/strategies/skewed-circles.cs
@@ -94,10 +94,10 @@ namespace MuseMapalyzr
     {
         public SkewedCirclesCalcPatternMultiplier(Pattern pattern) : base(pattern) { }
 
-        public override double CalcPatternMultiplier()
+        public override double CalcPatternMultiplier(bool ranked)
         {
             double nps = Pattern.Segments.First().NotesPerSecond;
-            double multiplier = PatternMultiplier.SkewedCircleMultiplier(nps); // replace with actual C# equivalent
+            double multiplier = PatternMultiplier.SkewedCircleMultiplier(nps, ranked); // replace with actual C# equivalent
             // Console.WriteLine($"SkewedCirclesCalcPatternMultiplier: {multiplier}");
             return multiplier;
         }

--- a/MuseMapalyzr/strategies/slow-stretch.cs
+++ b/MuseMapalyzr/strategies/slow-stretch.cs
@@ -76,9 +76,9 @@ namespace MuseMapalyzr
     {
         public SlowStretchPatternMultiplier(Pattern pattern) : base(pattern) { }
 
-        public override double CalcPatternMultiplier()
+        public override double CalcPatternMultiplier(bool ranked)
         {
-            return base.CalcPatternMultiplier();
+            return base.CalcPatternMultiplier(ranked);
         }
     }
 }

--- a/MuseMapalyzr/strategies/varying-stacks.cs
+++ b/MuseMapalyzr/strategies/varying-stacks.cs
@@ -70,10 +70,10 @@ namespace MuseMapalyzr
     {
         public VaryingStacksCalcPatternMultiplier(Pattern pattern) : base(pattern) { }
 
-        public override double CalcPatternMultiplier()
+        public override double CalcPatternMultiplier(bool ranked)
         {
             double nps = Pattern.Segments[0].NotesPerSecond;
-            double multiplier = PatternMultiplier.VaryingStacksMultiplier(nps); // assuming you have a method for this
+            double multiplier = PatternMultiplier.VaryingStacksMultiplier(nps, ranked); // assuming you have a method for this
             // Console.WriteLine($"VaryingStacksCalcPatternMultiplier: {multiplier}");
             return multiplier;
         }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Make sure in `MuseMapalyzr` there are the following directories:
 # TODO:
 - Ranked incorporates the "normal length" song threshold when determining the density.
 - Look at the pattern multipliers again.
-- With pattern multipliers for each map, actually log somewhere about what multipliers are affecting it etc.
+    - Patterns being grouped and then the multiplier being averaged after affects maps with patterns that fall under "Other".
 
 # Packages and stuff:
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Make sure in `MuseMapalyzr` there are the following directories:
 # TODO:
 - Ranked incorporates the "normal length" song threshold when determining the density.
 - Look at the pattern multipliers again.
+- With pattern multipliers for each map, actually log somewhere about what multipliers are affecting it etc.
 
 # Packages and stuff:
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Make sure in `MuseMapalyzr` there are the following directories:
 - It will output to `logs.log` in `MuseMapalyzr/logs`
 
 
-# Theory crafting and TO DO:
+# Theory crafting:
 - Ranked incorporates the "normal length" song threshold when determining the density.
-- Look at the pattern multipliers again.
+- Segment multipliers instead of pattern multipliers.
     - Instead of doing an average of PATTERN multipliers (e.g., NBT, Other, Skewed Circles, ...), we will do an average of SEGMENT multipliers.
       - Since with pattern multipliers there was the problem where Other pattern could be like 100 segments long or something and that gets treated the same as a pattern with 4 segments in the average calculation
     - For segments that fall under a pattern (e.g., two stacks and switches in an Even circle pattern), we would calculate the pattern multiplier and then overwrite the segment multipliers with it.
@@ -34,14 +34,6 @@ Make sure in `MuseMapalyzr` there are the following directories:
       - SO THE THEORY IS:
         - Patterns are things that are more "cheese-able" and that's why they are lower than the unpredictable segments.
         - In the future if we find more combinations of segments that are cheese-able, we could turn this into a recognisable pattern and weigh it lower.
-
-## Predictions
-- Erkfir: I think that "complex" maps with long stretches of patterns that would usually fall under "Other" like probably machine gun psystyle will g et buffed a fair bit in terms of the pattern multiplier.
-- theory crafting session occurred ***
-- Erkfir: after theory crafting: nvm i think we need to change some segment and pattern multipliers. 
-- Kartsu: I agree
-
-
 
 # Packages and stuff:
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,26 @@
 
 # Usage
 
+Make sure in `MuseMapalyzr` there are the following directories:
+- `analysis`
+- `difficulty_exports`
+- `logs`
+
 `cd MuseMapalyzr`
 
 - Process all difficulties in `data`: `dotnet run`
 - Process filtered difficulties: `dotnet run search string` e.g., `dotnet run speculation`
 - See the multiplier graph: `dotnet run graph`
 
+# Logging
+- You can configure the logging level by changing it in `Logger.cs`
+- `private static LogLevel DebugLevel = LogLevel.Debug;` <- Change to whatever you want.
+- It will output to `logs.log` in `MuseMapalyzr/logs`
+
 
 # TODO:
-## To be continued
-- Dark omen 7 NPS cap is like ~16 but then 7000 (which means it's not doing any cutting of notes) is like ~15?????
-- Is something wrong with the single stream density nerfing thing???
-- We set ranked NPS cap to 8 and unranked to 13 and that's when we discovered that dark omen was just being weird. 
-- Could it be a weird interaction with the density stuff? can't be though??? riught??
-
-
-## Still to do:
 - Ranked incorporates the "normal length" song threshold when determining the density.
-
+- Look at the pattern multipliers again.
 
 # Packages and stuff:
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+`cd MuseMapalyzr`
+`dotnet add package OxyPlot.WindowsForms --version 2.1.2`
+
+
+# Usage
+
+`cd MuseMapalyzr`
+
+- Process all difficulties in `data`: `dotnet run`
+- Process filtered difficulties: `dotnet run search string` e.g., `dotnet run speculation`
+- See the multiplier graph: `dotnet run graph`

--- a/README.md
+++ b/README.md
@@ -18,10 +18,30 @@ Make sure in `MuseMapalyzr` there are the following directories:
 - It will output to `logs.log` in `MuseMapalyzr/logs`
 
 
-# TODO:
+# Theory crafting and TO DO:
 - Ranked incorporates the "normal length" song threshold when determining the density.
 - Look at the pattern multipliers again.
-    - Patterns being grouped and then the multiplier being averaged after affects maps with patterns that fall under "Other".
+    - Instead of doing an average of PATTERN multipliers (e.g., NBT, Other, Skewed Circles, ...), we will do an average of SEGMENT multipliers.
+      - Since with pattern multipliers there was the problem where Other pattern could be like 100 segments long or something and that gets treated the same as a pattern with 4 segments in the average calculation
+    - For segments that fall under a pattern (e.g., two stacks and switches in an Even circle pattern), we would calculate the pattern multiplier and then overwrite the segment multipliers with it.
+    - For the Other pattern, we would just use each segment multipliers as is.
+    - *** We will likely need to make it so PATTERN multipliers are less than individual segment multipliers
+      - e.g., skewed circles currently capped at 1.75 should be less than the N-stacks which 4-stack is capped at 1.3x.
+      - So some mix of moving the caps up for segment multipliers, and moving the caps down for pattern multipliers.
+      - The THEORY is that if the segments don't fall into a pattern, then they're probably not in a predictable pattern and so more varied and harder.
+      - OBJECTION!!! What about 2-stack switch 3-stack switch 4-stack switch 2-stack etc.....
+        - This should be even circle...? Will need to check.
+      - SO THE THEORY IS:
+        - Patterns are things that are more "cheese-able" and that's why they are lower than the unpredictable segments.
+        - In the future if we find more combinations of segments that are cheese-able, we could turn this into a recognisable pattern and weigh it lower.
+
+## Predictions
+- Erkfir: I think that "complex" maps with long stretches of patterns that would usually fall under "Other" like probably machine gun psystyle will g et buffed a fair bit in terms of the pattern multiplier.
+- theory crafting session occurred ***
+- Erkfir: after theory crafting: nvm i think we need to change some segment and pattern multipliers. 
+- Kartsu: I agree
+
+
 
 # Packages and stuff:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-`cd MuseMapalyzr`
-`dotnet add package OxyPlot.WindowsForms --version 2.1.2`
-
 
 # Usage
 
@@ -9,3 +6,24 @@
 - Process all difficulties in `data`: `dotnet run`
 - Process filtered difficulties: `dotnet run search string` e.g., `dotnet run speculation`
 - See the multiplier graph: `dotnet run graph`
+
+
+# TODO:
+## To be continued
+- Dark omen 7 NPS cap is like ~16 but then 7000 (which means it's not doing any cutting of notes) is like ~15?????
+- Is something wrong with the single stream density nerfing thing???
+- We set ranked NPS cap to 8 and unranked to 13 and that's when we discovered that dark omen was just being weird. 
+- Could it be a weird interaction with the density stuff? can't be though??? riught??
+
+
+## Still to do:
+- Ranked incorporates the "normal length" song threshold when determining the density.
+
+
+# Packages and stuff:
+
+For the graphing of multipliers:
+
+`cd MuseMapalyzr`
+`dotnet add package OxyPlot.WindowsForms --version 2.1.2`
+


### PR DESCRIPTION
Changes:
- There is now ranked and unranked difficulties - each has their own config.
- Density calculation will not be skewed as heavily with dense single lane streams (ranked and unranked have different caps)
- Density calculation will take into account the length of the map (i.e., 1 second map will be treated like 91 second map with a whole lot of nothing for most of it.). Unranked has a threshold of 0 seconds so anything goes. This is changeable.
- Instead of averaging pattern multipliers, we do segment multipliers.
- Individual segment 'patterns' are weighted slightly more and patterns (e.g., NBT, even circles, skewed circles) are weighted less as the theory is that these are more 'cheesable' and/or predictable.
